### PR TITLE
update eval to eval2

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -77,8 +77,8 @@ query.select = select;
 		_field: function(field) {
 			this._expression = new Expression(field);
 		},
-		_add: function(eval, clean) {
-			this._eval += eval;
+		_add: function(eval2, clean) {
+			this._eval += eval2;
 			if (clean) this._expression = null;
 			return this;
 		},


### PR DESCRIPTION
`eval` causes an error on esm so i changed it to `eval2`.

`eval` is a reserved word in the newer versions of esm